### PR TITLE
Allow loading mocha options from .mocharc file

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ In case you want to in- or decrease the default timeout of 2000 ms, you can set 
 ## Mocha configuration with .mocharc file
 <!-- Please keep this section in sync with meteortesting:mocha package -->
 
-You can configure the mocha runner with a `.mocharc.js` or a `.mocharc.json` file at the root of your meteor app. You can find examples of config files [here](https://github.com/mochajs/mocha/tree/master/example/config).
+You can configure the mocha runner with a `.mocharc.js` or a `.mocharc.json` file at the root of your Meteor app. This package uses mocha programmatically, so it supports a constrained list of options.
 
-Please keep in mind that all options might not be compatible with how the Meteor test runner operates.
+* Read more about using mocha and supported options [here](https://github.com/mochajs/mocha/wiki/Using-Mocha-programmatically).
+* You can find examples of config files [here](https://github.com/mochajs/mocha/tree/master/example/config).
 
 ### Example
 
@@ -23,5 +24,6 @@ module.exports = {
   retries: 2,
   slow: 200,
   timeout: 10000,
+  grep: 'hello' // Only runs tests whose name contains this
 };
 ```

--- a/README.md
+++ b/README.md
@@ -5,3 +5,23 @@ This is an internal package. Please use [`meteortesting:mocha`](https://github.c
 ## In-/Decrease default test timeout
 
 In case you want to in- or decrease the default timeout of 2000 ms, you can set the environment variable `MOCHA_TIMEOUT` in your shell which will be picked up by this library and passed on to the mocha instance.
+
+## Mocha configuration with .mocharc file
+<!-- Please keep this section in sync with meteortesting:mocha package -->
+
+You can configure the mocha runner with a `.mocharc.js` or a `.mocharc.json` file at the root of your meteor app. You can find examples of config files [here](https://github.com/mochajs/mocha/tree/master/example/config).
+
+Please keep in mind that all options might not be compatible with how the Meteor test runner operates.
+
+### Example
+
+Feel free to start with this file as an example:
+
+```js
+module.exports = {
+  forbidOnly: process.env.IS_CI, // You could set this variable inside your continuous integration platform
+  retries: 2,
+  slow: 200,
+  timeout: 10000,
+};
+```

--- a/client.js
+++ b/client.js
@@ -10,7 +10,13 @@ if (Meteor.settings.public["MOCHA_TIMEOUT"]) {
   options.timeout = Meteor.settings.public["MOCHA_TIMEOUT"];
 }
 
+let config = {}
 
-mocha.setup(options);
+// Attempt to load config from .mocharc file
+try {
+  config = JSON.parse(__meteor_runtime_config__['meteortesting:mocha-core_config'])
+} catch (e) {}
+
+mocha.setup({...options, ...config});
 
 export { mocha };

--- a/client.js
+++ b/client.js
@@ -6,17 +6,18 @@ const options = {
   ui: 'bdd',
 };
 
+
+// Attempt to load config from .mocharc file
+try {
+  const config = JSON.parse(__meteor_runtime_config__['meteortesting:mocha-core_config'])
+  options = { ...options, ...config };
+} catch (e) {}
+
+
 if (Meteor.settings.public["MOCHA_TIMEOUT"]) {
   options.timeout = Meteor.settings.public["MOCHA_TIMEOUT"];
 }
 
-let config = {}
-
-// Attempt to load config from .mocharc file
-try {
-  config = JSON.parse(__meteor_runtime_config__['meteortesting:mocha-core_config'])
-} catch (e) {}
-
-mocha.setup({...options, ...config});
+mocha.setup(options);
 
 export { mocha };

--- a/loadConfig.js
+++ b/loadConfig.js
@@ -1,0 +1,29 @@
+import fs from 'fs';
+
+const pwd = process.env.PWD;
+
+let config = {};
+
+// Attempt to load .mocharc.js
+try {
+  const configFile = fs.readFileSync(`${pwd}/.mocharc.js`);
+  config = eval(configFile.toString());
+} catch (error) {
+  // Config is not set
+}
+
+// Attempt to load .mocharc.json
+try {
+  if (!config) {
+    const configFile = fs.readFileSync(`${pwd}/.mocharc.json`);
+    config = JSON.parse(configFile.toString());
+  }
+} catch (error2) {
+  // Config is not set
+}
+
+__meteor_runtime_config__['meteortesting:mocha-core_config'] = JSON.stringify(
+  config,
+);
+
+export default config;

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ import Fiber from 'fibers';
 import "./setup"
 import Mocha from 'mocha';
 import "./cleanup"
+import config from './loadConfig';
 
 function setupGlobals(mocha) {
   var mochaExports = {};
@@ -116,7 +117,7 @@ if (process.env.MOCHA_TIMEOUT) {
   Meteor.settings.public["MOCHA_TIMEOUT"] = process.env.MOCHA_TIMEOUT;
 }
 
-const mochaInstance = new Mocha(options);
+const mochaInstance = new Mocha({ ...options, ...config });
 setupGlobals(mochaInstance);
 
 export { mochaInstance, setupGlobals, Mocha };

--- a/server.js
+++ b/server.js
@@ -1,7 +1,8 @@
-import Fiber from 'fibers';
 import "./setup"
-import Mocha from 'mocha';
 import "./cleanup"
+
+import Fiber from 'fibers';
+import Mocha from 'mocha';
 import config from './loadConfig';
 
 function setupGlobals(mocha) {
@@ -109,7 +110,8 @@ function setupGlobals(mocha) {
 // can use to ensure they work well with other test driver packages.
 const options = {
   ui: 'bdd',
-  ignoreLeaks: true
+  ignoreLeaks: true,
+  ...config,
 };
 
 if (process.env.MOCHA_TIMEOUT) {
@@ -117,7 +119,7 @@ if (process.env.MOCHA_TIMEOUT) {
   Meteor.settings.public["MOCHA_TIMEOUT"] = process.env.MOCHA_TIMEOUT;
 }
 
-const mochaInstance = new Mocha({ ...options, ...config });
+const mochaInstance = new Mocha(options);
 setupGlobals(mochaInstance);
 
 export { mochaInstance, setupGlobals, Mocha };


### PR DESCRIPTION
This allows you to add a `.mocharc.js` or `.mocharc.json` file to the root of your meteor repo, which is then read here and added to the options of mocha.

I tested it successfully in my apps with `{ forbidOnly: true }`.

Closes #4 